### PR TITLE
Update tagged player glow and base colors

### DIFF
--- a/Assets/Prefabs/Aga.prefab
+++ b/Assets/Prefabs/Aga.prefab
@@ -76,7 +76,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Netcode.Runtime::Unity.Netcode.NetworkObject
-  GlobalObjectIdHash: 3051191352
+  GlobalObjectIdHash: 3990490726
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -238,6 +238,15 @@ MonoBehaviour:
   walkSpeed: 3
   sprintSpeed: 8
   RotateSpeed: 30
+  maxStamina: 100
+  staminaDrainRate: 20
+  staminaRegenRateSlow: 5
+  staminaRegenRateFast: 15
+  sprintSpeedThreshold: 0.5
+  walkSpeedThreshold: 0.2
+  exhaustedSpeedMultiplier: 0.3
+  minStaminaToSprint: 5
+  taggedStaminaBoostMultiplier: 1.5
   minX: -17
   maxX: 17
   minZ: -13
@@ -253,6 +262,75 @@ MonoBehaviour:
     m_InternalValue: 0
   lastTagTimeNet:
     m_InternalValue: 0
+  colorNet:
+    m_InternalValue:
+      utf8LengthInBytes: 7
+      bytes:
+        offset0000:
+          byte0000: 35
+          byte0001: 68
+          byte0002: 54
+          byte0003: 56
+          byte0004: 55
+          byte0005: 55
+          byte0006: 70
+          byte0007: 0
+          byte0008: 0
+          byte0009: 0
+          byte0010: 0
+          byte0011: 0
+          byte0012: 0
+          byte0013: 0
+          byte0014: 0
+          byte0015: 0
+        offset0016:
+          byte0000: 0
+          byte0001: 0
+          byte0002: 0
+          byte0003: 0
+          byte0004: 0
+          byte0005: 0
+          byte0006: 0
+          byte0007: 0
+          byte0008: 0
+          byte0009: 0
+          byte0010: 0
+          byte0011: 0
+          byte0012: 0
+          byte0013: 0
+          byte0014: 0
+          byte0015: 0
+        offset0032:
+          byte0000: 0
+          byte0001: 0
+          byte0002: 0
+          byte0003: 0
+          byte0004: 0
+          byte0005: 0
+          byte0006: 0
+          byte0007: 0
+          byte0008: 0
+          byte0009: 0
+          byte0010: 0
+          byte0011: 0
+          byte0012: 0
+          byte0013: 0
+          byte0014: 0
+          byte0015: 0
+        byte0048: 0
+        byte0049: 0
+        byte0050: 0
+        byte0051: 0
+        byte0052: 0
+        byte0053: 0
+        byte0054: 0
+        byte0055: 0
+        byte0056: 0
+        byte0057: 0
+        byte0058: 0
+        byte0059: 0
+        byte0060: 0
+        byte0061: 0
 --- !u!114 &5568033458682530780
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -267,8 +345,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::TaggedPlayerVisualizer
   ShowTopMostFoldoutHeaderGroup: 1
   playerSkinRenderer: {fileID: 8576045237320093323}
-  glowColor: {r: 1, g: 0.3, b: 0.3, a: 1}
-  glowIntensity: 2
+  glowColor: {r: 0.7803922, g: 0.3137255, b: 0.3137255, a: 1}
+  glowIntensity: 1.25
   markerPrefab: {fileID: 2861896397478858066, guid: 7c48f679abde14eaa9db02b4b115a613, type: 3}
   markerOffset: {x: 0, y: 2.5, z: 0}
 --- !u!1001 &2472634209218968432

--- a/Assets/Scripts/PlayerColorManager.cs
+++ b/Assets/Scripts/PlayerColorManager.cs
@@ -4,16 +4,16 @@ public class PlayerColorManager : MonoBehaviour
 {
     public static readonly Color[] AvailableColors = new Color[]
     {
-        Color.red,
-        Color.blue,
-        Color.green,
-        Color.yellow,
-        Color.cyan,
-        Color.magenta,
-        new Color(1f, 0.5f, 0f),
-        new Color(0.5f, 0f, 1f),
-        Color.white,
-        Color.black
+        ColorUtility.TryParseHtmlString("#D6877F", out Color red) ? red : Color.red,
+        ColorUtility.TryParseHtmlString("#7fb3d6", out Color blue) ? blue : Color.blue,
+        ColorUtility.TryParseHtmlString("#92d67f", out Color green) ? green : Color.green,
+        ColorUtility.TryParseHtmlString("#fae989", out Color yellow) ? yellow : Color.yellow,
+        ColorUtility.TryParseHtmlString("#7fd6b5", out Color cyan) ? cyan : Color.cyan,
+        ColorUtility.TryParseHtmlString("#d67fd2", out Color magenta) ? magenta : Color.magenta,
+        ColorUtility.TryParseHtmlString("#f0a660", out Color orange) ? orange : new Color(1f, 0.5f, 0f),
+        ColorUtility.TryParseHtmlString("#a07fd6", out Color purple) ? purple : new Color(0.5f, 0f, 1f),
+        ColorUtility.TryParseHtmlString("#ececec", out Color white) ? white : Color.white,
+        ColorUtility.TryParseHtmlString("#222224", out Color black) ? black : Color.black,
     };
 
     public static readonly string[] ColorNames = new string[]

--- a/Assets/Scripts/TaggedPlayerVisualizer.cs
+++ b/Assets/Scripts/TaggedPlayerVisualizer.cs
@@ -6,8 +6,8 @@ public class TaggedPlayerVisualizer : NetworkBehaviour
 {
     [Header("Glow Settings")]
     [SerializeField] private SkinnedMeshRenderer playerSkinRenderer;
-    [SerializeField] private Color glowColor = new Color(1f, 0.3f, 0.3f);
-    [SerializeField] private float glowIntensity = 2f;
+    [SerializeField] private Color glowColor;
+    [SerializeField] private float glowIntensity;
 
     [Header("Marker Settings")]
     [SerializeField] private GameObject markerPrefab;
@@ -62,6 +62,8 @@ public class TaggedPlayerVisualizer : NetworkBehaviour
             playerMovement.isTaggedNet.OnValueChanged += OnTaggedStateChanged;
             UpdateVisualization(playerMovement.isTaggedNet.Value);
         }
+        UnityEngine.ColorUtility.TryParseHtmlString(PlayerPrefs.GetString("Color"), out var skinColor);
+        glowColor = skinColor;
     }
 
     public override void OnNetworkDespawn()


### PR DESCRIPTION
Uses PlayerPrefs to assign color instead. Also tones down the default Unity colors. I feel like that makes it easier on the eyes, but that is up for debate.