### PR TITLE
Only show boost particles when moving

### DIFF
--- a/Assets/Scripts/Tag/PlayerTagMovement.cs
+++ b/Assets/Scripts/Tag/PlayerTagMovement.cs
@@ -389,13 +389,14 @@ public class PlayerTagMovement : NetworkBehaviour
             // TODO : use a range instead of ONE value to prevent jitter!
             isSprintingNet.Value = moveSpeed > sprintSpeedThreshold;
             isWalkingNet.Value = !isSprintingNet.Value;
-            isShowingBoostParticlesNet.Value = isBoosting;
+            isShowingBoostParticlesNet.Value = isBoosting && (USING_PLAYPULSE ? pedalSpeed > 0f : input.sqrMagnitude > 0.1f);
         }
         else
         {
             isWalkingNet.Value = false;
             isSprintingNet.Value = false;
             animator.speed = 1.0f;
+            isShowingBoostParticlesNet.Value = false;
         }
 
         // Lastly, if neither moving or tagging, check if taunting.


### PR DESCRIPTION
Uses USING_PLAYPULSE to limit the animation, but should work on both keyboard and the bike if it is set to true, either way.